### PR TITLE
Fix and generalize CLI

### DIFF
--- a/src/umls_downloader/cli.py
+++ b/src/umls_downloader/cli.py
@@ -38,7 +38,8 @@ def main(version: Optional[str], url: Optional[str], output: Optional[str]):
     resource via a custom URL."""
     if url and output:
         download_tgt(url=url, path=output)
-    download_umls(version=version)
+    else:
+        download_umls(version=version)
 
 
 if __name__ == "__main__":

--- a/src/umls_downloader/cli.py
+++ b/src/umls_downloader/cli.py
@@ -19,7 +19,7 @@ from typing import Optional
 import click
 from more_click import verbose_option
 
-from .api import download_umls
+from .api import download_tgt, download_umls
 
 __all__ = [
     "main",
@@ -28,11 +28,16 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 
-@click.group()
+@click.command()
 @verbose_option
 @click.option("--version")
-def main(version: Optional[str]):
-    """Ensure the given version of the UMLS."""
+@click.option("--url")
+@click.option("--output")
+def main(version: Optional[str], url: Optional[str], output: Optional[str]):
+    """Download the given version of the UMLS or another UMLS-controlled
+    resource via a custom URL."""
+    if url and output:
+        download_tgt(url=url, path=output)
     download_umls(version=version)
 
 

--- a/src/umls_downloader/cli.py
+++ b/src/umls_downloader/cli.py
@@ -33,13 +33,13 @@ logger = logging.getLogger(__name__)
 @click.option("--version")
 @click.option("--url")
 @click.option("--output")
-def main(version: Optional[str], url: Optional[str], output: Optional[str]):
-    """Download the given version of the UMLS or another UMLS-controlled
-    resource via a custom URL."""
+@click.option("--api-key")
+def main(version: Optional[str], url: Optional[str], output: Optional[str], api_key: Optional[str]):
+    """Download the given version of the UMLS or another UMLS-controlled resource via a custom URL."""
     if url and output:
-        download_tgt(url=url, path=output)
+        download_tgt(url=url, path=output, api_key=api_key)
     else:
-        download_umls(version=version)
+        download_umls(version=version, api_key=api_key)
 
 
 if __name__ == "__main__":

--- a/src/umls_downloader/cli.py
+++ b/src/umls_downloader/cli.py
@@ -30,10 +30,16 @@ logger = logging.getLogger(__name__)
 
 @click.command()
 @verbose_option
-@click.option("--version")
-@click.option("--url")
-@click.option("--output")
-@click.option("--api-key")
+@click.option("--version", help="Version of UMLS to download if not using --url")
+@click.option(
+    "--url", help="The URL for a file to be downloaded through the UMLS ticket granting system."
+)
+@click.option("--output", help="The local file path to download a file to if using --url")
+@click.option(
+    "--api-key",
+    help="The API key for the UMLS ticket granting system. If not given, uses pystow to load."
+    " Get one at https://uts.nlm.nih.gov/uts/edit-profile. ",
+)
 def main(version: Optional[str], url: Optional[str], output: Optional[str], api_key: Optional[str]):
     """Download the given version of the UMLS or another UMLS-controlled resource via a custom URL."""
     if url and output:

--- a/src/umls_downloader/version.py
+++ b/src/umls_downloader/version.py
@@ -38,4 +38,4 @@ def get_version(with_git_hash: bool = False):
 
 
 if __name__ == "__main__":
-    print(get_version(with_git_hash=True))  # noqa:T001
+    print(get_version(with_git_hash=True))  # noqa:T201


### PR DESCRIPTION
This PR adds a general URL/output path option pair for the CLI to allow downloading any UMLS ticketing system controlled resource. With the special case for UMLS itself still there, I'm not sure this is the best API design, but it works. I also changed `@click.group()` to `@click.command()` because the former didn't work for me.

Fixes #3 